### PR TITLE
Dev - PR 12-14 from KnowLingo

### DIFF
--- a/app/api/execute-workflow/route.ts
+++ b/app/api/execute-workflow/route.ts
@@ -4,34 +4,16 @@ import { validateWorkflow, validateApiKeys } from "@charliesu/workflow-core"
 import type { ExecutionUpdate } from "@charliesu/workflow-core"
 import { shouldUseDemoMode, hasDemoData as hasNewDemoData, resolveScanModes, type ScanMode } from "@/lib/demo-mode"
 import { getDemoWorkflowResult, hasDemoData as hasLegacyDemoData } from "@/lib/demo-data"
+import { RateLimiter, rateLimitKey } from "@/lib/security/rate-limit"
+import { detectWorkflowCycle } from "@/lib/security/workflow-graph"
 
 export const maxDuration = 30
 
 // ============================================================================
-// Rate Limiting
+// Rate Limiting (sliding window; in-memory store, pluggable for Redis/KV)
 // ============================================================================
 
-const rateLimitStore = new Map<string, { count: number; resetTime: number }>()
-
-function checkRateLimit(identifier: string): boolean {
-  const now = Date.now()
-  const limit = rateLimitStore.get(identifier)
-
-  if (!limit || now > limit.resetTime) {
-    rateLimitStore.set(identifier, {
-      count: 1,
-      resetTime: now + 60000, // 10 requests per minute
-    })
-    return true
-  }
-
-  if (limit.count >= 10) {
-    return false
-  }
-
-  limit.count++
-  return true
-}
+const limiter = new RateLimiter({ limit: 10, windowMs: 60_000 }) // 10 requests / minute / client
 
 // ============================================================================
 // Input Sanitization
@@ -63,14 +45,20 @@ function sanitizeInput(input: any, skipKeys: string[] = []): any {
 // ============================================================================
 
 export async function POST(req: Request) {
-  // Rate limiting
-  const clientId = req.headers.get("x-forwarded-for") || "anonymous"
-  if (!checkRateLimit(clientId)) {
+  // Rate limiting (per client IP)
+  const clientIp = (req.headers.get("x-forwarded-for") || "").split(",")[0].trim() || "anonymous"
+  const rl = await limiter.check(rateLimitKey(clientIp))
+  if (!rl.allowed) {
     return new Response(
-      JSON.stringify({ error: "Rate limit exceeded. Please try again in a minute." }),
+      JSON.stringify({ error: "Rate limit exceeded. Please try again shortly." }),
       {
         status: 429,
-        headers: { "Content-Type": "application/json" },
+        headers: {
+          "Content-Type": "application/json",
+          "Retry-After": String(Math.ceil(rl.resetMs / 1000)),
+          "X-RateLimit-Limit": String(rl.limit),
+          "X-RateLimit-Remaining": String(rl.remaining),
+        },
       }
     )
   }
@@ -224,6 +212,18 @@ export async function POST(req: Request) {
         // ============================================================================
         // Validation (Cycles, SSRF)
         // ============================================================================
+
+        // Fail-closed cycle detection before execution (independent of the engine's
+        // own validation) — a cyclic graph could otherwise drive an infinite loop.
+        const cycleCheck = detectWorkflowCycle(sanitizedNodes, edges)
+        if (cycleCheck.hasCycle) {
+          sendUpdate({
+            type: "error",
+            error: `Workflow contains a cycle (${(cycleCheck.cycle || []).join(" → ")}). Remove the circular dependency before running.`,
+          })
+          controller.close()
+          return
+        }
 
         const validationIssues = validateWorkflow(sanitizedNodes, edges)
         const errors = validationIssues.filter((issue) => issue.type === "error")

--- a/components/api-settings-dialog.tsx
+++ b/components/api-settings-dialog.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState, useEffect } from "react"
+import { encryptApiKeys, decryptApiKeys } from "@/lib/security/encryption"
 import {
   Dialog,
   DialogContent,
@@ -50,17 +51,24 @@ export function ApiSettingsDialog({ open, onOpenChange }: ApiSettingsDialogProps
   const [validationStatus, setValidationStatus] = useState<Record<string, boolean>>({})
 
   useEffect(() => {
-    if (typeof window !== "undefined") {
+    if (typeof window === "undefined") return
+    let cancelled = false
+    ;(async () => {
       const stored = localStorage.getItem("ai-agent-api-keys")
-      const keys = stored ? JSON.parse(stored) : {}
+      const raw = stored ? JSON.parse(stored) : {}
+      // Decrypt at-rest values (legacy plaintext passes through unchanged).
+      const keys = await decryptApiKeys(raw)
+      if (cancelled) return
       setSettings(keys)
 
-      // Validate all stored keys
       const status: Record<string, boolean> = {}
       Object.entries(keys).forEach(([provider, key]) => {
         status[provider] = validateApiKey(provider, key as string)
       })
       setValidationStatus(status)
+    })()
+    return () => {
+      cancelled = true
     }
   }, [open])
 
@@ -73,8 +81,10 @@ export function ApiSettingsDialog({ open, onOpenChange }: ApiSettingsDialogProps
     setValidationStatus(newStatus)
   }
 
-  const handleSave = () => {
-    localStorage.setItem("ai-agent-api-keys", JSON.stringify(settings))
+  const handleSave = async () => {
+    // Encrypt at rest (AES-GCM via Web Crypto) before persisting.
+    const encrypted = await encryptApiKeys(settings as Record<string, string>)
+    localStorage.setItem("ai-agent-api-keys", JSON.stringify(encrypted))
     onOpenChange(false)
   }
 

--- a/components/execution-panel.tsx
+++ b/components/execution-panel.tsx
@@ -10,6 +10,7 @@ import { Badge } from "@/components/ui/badge"
 import { WorkflowInputDialog } from "@/components/workflow-input-dialog"
 import type { StartNodeData } from "@/components/nodes/start-node"
 import { GitHubScannerResults } from "@/components/github-scanner-results"
+import { decryptApiKeys, decryptValue } from "@/lib/security/encryption"
 
 type ExecutionResult = {
   nodeId: string
@@ -165,14 +166,18 @@ export function ExecutionPanel({
     })
 
     try {
-      const apiKeys = typeof window !== "undefined" ? localStorage.getItem("ai-agent-api-keys") : null
-      const keys = apiKeys ? JSON.parse(apiKeys) : {}
+      const storedKeys = typeof window !== "undefined" ? localStorage.getItem("ai-agent-api-keys") : null
+      // Decrypt at-rest BYOK keys before sending (legacy plaintext passes through).
+      const keys = storedKeys ? await decryptApiKeys(JSON.parse(storedKeys)) : {}
 
       // Two-axis BYOK: GitHub token => real scan DATA; AI key (in `keys`) => LLM NARRATIVE.
-      // Use the dialog's choice when present; otherwise fall back to any saved token.
-      const githubToken = scanOptions
-        ? scanOptions.githubToken
-        : (typeof window !== "undefined" ? localStorage.getItem("ai-agent-github-token") || undefined : undefined)
+      // Use the dialog's choice when present (already plaintext); otherwise fall back to
+      // the saved (encrypted) token and decrypt it.
+      let githubToken = scanOptions ? scanOptions.githubToken : undefined
+      if (!scanOptions && typeof window !== "undefined") {
+        const storedToken = localStorage.getItem("ai-agent-github-token")
+        githubToken = storedToken ? await decryptValue(storedToken) : undefined
+      }
 
       const response = await fetch("/api/execute-workflow", {
         method: "POST",

--- a/components/workflow-input-dialog.tsx
+++ b/components/workflow-input-dialog.tsx
@@ -8,6 +8,7 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { AlertCircle } from "lucide-react"
 import { Switch } from "@/components/ui/switch"
+import { encryptValue, decryptValue } from "@/lib/security/encryption"
 import type { StartNodeData } from "@/components/nodes/start-node"
 
 type ScanOptions = { githubToken?: string; scanMode?: "demo" | "real" }
@@ -46,11 +47,23 @@ export function WorkflowInputDialog({ open, startNodes, onSubmit, onCancel, work
       setInputs(newInputs)
       setErrors({})
 
-      // Scanner: load any saved GitHub token and default the toggle accordingly.
+      // Scanner: load + decrypt any saved GitHub token (legacy plaintext passes through).
       if (isScanner && typeof window !== "undefined") {
-        const savedToken = localStorage.getItem("ai-agent-github-token") || ""
-        setGithubToken(savedToken)
-        setRealScan(Boolean(savedToken))
+        const stored = localStorage.getItem("ai-agent-github-token") || ""
+        if (stored) {
+          decryptValue(stored)
+            .then((token) => {
+              setGithubToken(token)
+              setRealScan(Boolean(token))
+            })
+            .catch(() => {
+              setGithubToken("")
+              setRealScan(false)
+            })
+        } else {
+          setGithubToken("")
+          setRealScan(false)
+        }
       }
     }
   }, [open, startNodes, isScanner])
@@ -90,7 +103,7 @@ export function WorkflowInputDialog({ open, startNodes, onSubmit, onCancel, work
     }
   }
 
-  const handleSubmit = () => {
+  const handleSubmit = async () => {
     const newErrors: Record<string, string> = {}
 
     // Validate all inputs
@@ -112,7 +125,7 @@ export function WorkflowInputDialog({ open, startNodes, onSubmit, onCancel, work
     if (isScanner) {
       const token = githubToken.trim()
       if (typeof window !== "undefined") {
-        if (token) localStorage.setItem("ai-agent-github-token", token)
+        if (token) localStorage.setItem("ai-agent-github-token", await encryptValue(token))
         else localStorage.removeItem("ai-agent-github-token")
       }
       // realScan off => force demo; on => real (token optional: public repos scan tokenless).

--- a/docs/AI-Security/osv-scanner/01-ssrf-cycle-detection-rate-limiting-2026-06-14-draft.md
+++ b/docs/AI-Security/osv-scanner/01-ssrf-cycle-detection-rate-limiting-2026-06-14-draft.md
@@ -1,0 +1,248 @@
+# Tutorial 01 — Securing Workflow Egress & Execution: SSRF Allowlisting, Cycle Detection, and Rate Limiting
+
+| | |
+|---|---|
+| **Series** | AI Security Tutorials — TopFlow |
+| **Level** | Intermediate |
+| **Source PR** | #12 (`feat(security): SSRF guard + cycle detection + rate limiter (M1 P0)`) |
+| **Files** | `lib/security/ssrf.ts`, `lib/security/workflow-graph.ts`, `lib/security/rate-limit.ts`, `lib/topflow-execution-engine.ts`, `app/api/execute-workflow/route.ts` |
+| **Status** | Draft — 2026-06-14 |
+| **Est. time** | 60–90 min (with labs) |
+
+### Learning objectives
+By the end you can: (1) explain SSRF, execution-graph DoS, and resource-exhaustion in the context of an
+LLM workflow engine; (2) build a threat model and attack trees for a server-side "agent" that fetches
+URLs on a user's behalf; (3) justify allowlist vs. blocklist, fail-closed placement, and sliding-window
+limiting; (4) read and critique the production implementation, including what it deliberately leaves open.
+
+---
+
+## 1. Context & architecture
+
+TopFlow lets users compose **workflows** from nodes (start, httpRequest, textModel, javascript, …) and
+runs them server-side at `POST /api/execute-workflow` via `TopFlowExecutionEngine`. One node type — the
+**HTTP Request node** — fetches an arbitrary URL **from the server**. That single capability turns the
+engine into a *confused deputy*: the server makes outbound requests chosen by (untrusted) user input.
+
+This is the classic precondition for **SSRF (Server-Side Request Forgery)**. Combine it with two other
+realities of a workflow engine:
+- the workflow is a **directed graph** the user controls → a **cycle** can loop execution forever;
+- the endpoint is **public and unauthenticated** → it can be **hammered** for DoS or cost.
+
+```mermaid
+flowchart LR
+  U[User-supplied workflow] --> R[/api/execute-workflow/]
+  R --> ENG[TopFlowExecutionEngine]
+  ENG -->|HTTP Request node| NET[(Outbound fetch\nserver-side)]
+  NET -. attacker target .-> META[(169.254.169.254\ncloud metadata)]
+  NET -. attacker target .-> INT[(10.0.0.0/8 internal services)]
+  ENG -. cyclic graph .-> LOOP{{infinite loop\ncredit burn}}
+  R -. unauthenticated flood .-> DOS{{DoS / cost}}
+  classDef bad fill:#fee,stroke:#c00,color:#900;
+  class META,INT,LOOP,DOS bad
+```
+
+PR #12 adds three controls at exactly these points: an **SSRF egress guard** on the outbound fetch, a
+**fail-closed cycle check** before execution, and a **rate limiter** on the route.
+
+## 2. Security mechanisms (the concepts)
+
+- **SSRF egress filtering.** Before the server fetches a user-controlled URL, validate the *destination*.
+  Two philosophies: **blocklist** (deny known-bad: private ranges, metadata IP) vs **allowlist** (permit
+  only known-good hosts). Allowlists are stronger but brittle for a general fetch node; this PR uses a
+  strict blocklist of non-routable/private space plus a scheme allowlist (`http`/`https` only).
+- **Cycle detection (availability).** A workflow is a graph; executing a graph with a directed cycle can
+  loop forever. Detect cycles **before** running and **fail closed** (refuse to execute).
+- **Rate limiting (availability & cost).** Bound how often a client can call an expensive endpoint.
+  A **sliding window** counts requests in the trailing N seconds (smoother than a fixed window that
+  resets on a boundary and allows 2× bursts).
+
+Each is a different leg of the **CIA triad**: SSRF → confidentiality/integrity of internal systems;
+cycles & rate limits → availability (and, for an AI product, **API-credit cost**, which is availability's
+wallet-shaped cousin).
+
+## 3. Threat model (for this architecture)
+
+**Assets:** cloud instance metadata (IAM creds via `169.254.169.254`), internal/private services
+(databases, admin panels on `10/172.16-31/192.168`), the user's BYOK secrets in process memory, server
+availability, and AI-provider credits.
+
+**Trust boundary:** the `POST /api/execute-workflow` request body is **fully attacker-controlled**
+(nodes, edges, URLs). Everything past it runs with the **server's** network position and privileges.
+
+**Entry points:** the HTTP Request node's `url`/`method`/`headers`/`body`; the workflow graph (`nodes`,
+`edges`); the request itself (volume).
+
+**STRIDE for the HTTP node + engine:**
+
+| STRIDE | Threat in this system |
+|---|---|
+| **S**poofing | Server identity used to reach internal services that trust the VPC. |
+| **T**ampering | — (read-mostly here) |
+| **R**epudiation | Unauthenticated floods are hard to attribute (mitigated by per-IP keying + logs). |
+| **I**nfo disclosure | **SSRF → cloud metadata / internal endpoints** (the headline risk). |
+| **D**enial of service | **Cyclic graph** (infinite loop) and **endpoint flooding**. |
+| **E**levation of privilege | Metadata creds → lateral movement / IAM escalation. |
+
+Mapped to the LLM-app canon: SSRF + DoS sit under **OWASP LLM06 (Excessive Agency)** and the classic
+**OWASP API/Web SSRF**; cost-via-loops connects to **Unbounded Consumption**.
+
+## 4. Attack trees
+
+**Attack tree A — Reach internal/metadata via the HTTP node**
+```
+GOAL: make the server fetch an internal/metadata target
+├── A1 direct private IP            (http://10.0.0.5/admin)            [blocked: isBlockedIpv4]
+├── A2 cloud metadata IP            (http://169.254.169.254/…)         [blocked: link-local /16]
+├── A3 loopback                     (http://127.0.0.1:3000/…)          [blocked: 127/8]
+├── A4 IPv6 loopback / ULA          (http://[::1]/, fd00::/fe80::)     [blocked: isBlockedIpv6]
+├── A5 IPv4-mapped IPv6             (http://[::ffff:10.0.0.1]/)        [blocked: mapped→v4 check]
+├── A6 alternate scheme             (file://, gopher://)               [blocked: scheme allowlist]
+├── A7 internal hostname            (db.internal, svc.local)           [blocked: .internal/.local]
+├── A8 abuse engine internal route  (relative "/api/…")                [EXEMPT by design — see §5]
+└── A9 DNS rebinding                 (evil.com → resolves to 10.x)      [NOT fully closed — residual risk]
+```
+
+**Attack tree B — Exhaust the system**
+```
+GOAL: deny service / burn credits
+├── B1 cyclic workflow              (a→b→c→a, or self-loop a→a)        [blocked: detectWorkflowCycle, fail-closed]
+└── B2 flood the endpoint           (N requests/sec from one client)   [throttled: sliding-window limiter]
+        └── B2a rotate source IPs                                       [partial: per-IP only; per-token & WAF future]
+```
+
+The leaves marked *blocked* map 1:1 to code in §6. The two unclosed leaves (**A9 DNS rebinding**,
+**B2a IP rotation**) are the honest edges of this PR and are called out as residual risk — a recurring
+theme in security: *you ship the high-value mitigations and document the remainder.*
+
+## 5. Design considerations (decisions & trade-offs)
+
+1. **Blocklist, not allowlist — for now.** A general HTTP node must reach arbitrary public APIs, so a
+   host allowlist would break the feature. We blocklist non-routable space + restrict schemes. (A
+   per-workflow *allowlist* is a sensible future opt-in for high-assurance deployments.)
+2. **Exempt engine-generated relative routes (the critical nuance).** The scanner calls its own API as a
+   *relative* path (`/api/scan/github/…`), which the engine rewrites to `localhost`. If the SSRF guard
+   blocked loopback indiscriminately, **it would break the product's own real-scan path.** So the guard
+   is applied **only to user-supplied absolute URLs**; engine-issued relative routes are trusted. This
+   is the key design insight: *the same destination (localhost) is allowed or denied based on
+   provenance, not just value.* The risk it introduces — a user typing an absolute `http://localhost…` —
+   is itself caught (absolute → checked → blocked).
+3. **Hostname/literal-IP check vs. full DNS resolution.** Resolving DNS and checking the *resolved* IP
+   (with pinning) defeats DNS rebinding but adds latency, complexity, and its own pitfalls in serverless.
+   We ship the high-coverage literal check now and document rebinding as defense-in-depth follow-up.
+4. **Fail closed, and early.** Cycle detection runs in the route **before** the engine starts and
+   refuses to execute on any cycle — independent of the workflow-core library's own validation (defense
+   in depth). A returned cycle *path* makes the error actionable.
+5. **Sliding window + pluggable store.** Sliding-window beats fixed-window burst-doubling. The store is
+   an interface (`RateLimitStore`); the default is in-memory (per instance), with a documented
+   Redis/Vercel-KV adapter as the durability follow-up. We deliberately **did not add a dependency**
+   (the repo's CI uses a frozen lockfile), trading cross-instance durability now for a clean, testable,
+   shippable increment.
+6. **Per-IP keying (with token support ready).** The execute route keys by client IP (the token lives in
+   the body, read once downstream). `rateLimitKey(ip, token?)` already supports per-token limiting for
+   header-token routes, and **hashes** the token so secrets never appear in keys/logs.
+
+## 6. Implementation case study (PR #12)
+
+**SSRF guard — `lib/security/ssrf.ts`.** Pure, dependency-free, unit-testable. Literal-IP range checks +
+scheme allowlist:
+```ts
+function isBlockedIpv4(ip: string): boolean {
+  const [a, b] = ip.split(".").map(Number)
+  if (a === 10) return true                          // 10/8 private
+  if (a === 127) return true                         // 127/8 loopback
+  if (a === 169 && b === 254) return true            // 169.254/16 link-local (cloud metadata)
+  if (a === 172 && b >= 16 && b <= 31) return true   // 172.16/12 private
+  if (a === 192 && b === 168) return true            // 192.168/16 private
+  if (a === 100 && b >= 64 && b <= 127) return true  // 100.64/10 CGNAT
+  if (a >= 224) return true                           // multicast/reserved
+  return false
+}
+export function checkOutboundUrl(rawUrl: string): SsrfCheck {
+  let u: URL; try { u = new URL(rawUrl) } catch { return { safe: false, reason: `invalid URL` } }
+  if (u.protocol !== "http:" && u.protocol !== "https:") return { safe: false, reason: "blocked scheme" }
+  if (isBlockedHost(u.hostname)) return { safe: false, reason: "blocked host" }
+  return { safe: true }
+}
+```
+
+**Engine integration — `lib/topflow-execution-engine.ts`.** The guard runs after interpolation, right
+before `fetch`, and *only* for absolute URLs (the provenance rule from §5.2):
+```ts
+let finalUrl = interpolatedUrl
+if (interpolatedUrl.startsWith('/')) {
+  finalUrl = `${process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000'}${interpolatedUrl}` // trusted internal route
+} else {
+  assertSafeOutboundUrl(finalUrl) // SSRF guard — user-supplied absolute URLs only
+}
+```
+
+**Cycle detection — `lib/security/workflow-graph.ts`.** DFS three-color coloring; returns the cycle path:
+```ts
+// GRAY = on the current DFS stack; a back-edge to a GRAY node is a cycle
+if (color.get(next) === GRAY) { const start = stack.indexOf(next); return stack.slice(start).concat(next) }
+```
+Wired fail-closed in the route **before** execution:
+```ts
+const cycleCheck = detectWorkflowCycle(sanitizedNodes, edges)
+if (cycleCheck.hasCycle) { sendUpdate({ type: "error", error: `Workflow contains a cycle (${cycleCheck.cycle?.join(" → ")})…` }); controller.close(); return }
+```
+
+**Rate limiting — `lib/security/rate-limit.ts`.** Sliding-window log + injectable clock (for tests) +
+pluggable store; the route returns standard headers:
+```ts
+const hits = await this.store.hit(key, now, this.windowMs)   // timestamps within trailing window
+return { allowed: hits.length <= this.limit, remaining: Math.max(0, this.limit - hits.length), … }
+```
+```ts
+const rl = await limiter.check(rateLimitKey(clientIp))
+if (!rl.allowed) return new Response(JSON.stringify({error:"Rate limit exceeded…"}),
+  { status: 429, headers: { "Retry-After": String(Math.ceil(rl.resetMs/1000)), "X-RateLimit-Remaining": String(rl.remaining) } })
+```
+
+**Testing.** Each module ships Jest unit tests (`lib/security/__tests__/`): SSRF block/allow tables
+(incl. `172.32.0.1` *allowed* — just outside the /12 — to catch off-by-one range bugs), cycle/DAG/self-
+loop cases, and a clock-injected limiter (allow N, block N+1, reset after the window). The logic was
+also exercised end-to-end locally (30/30 assertions) before CI.
+
+**Deliberately deferred** (and documented, not hidden): DNS-rebinding resolution, cross-instance durable
+rate-limit store (needs a dep), and the JS-node sandbox replacement (separate W1 slice).
+
+## 7. Hands-on labs
+
+> Run locally: `pnpm install && pnpm dev`. Unit tests: `pnpm test`.
+
+1. **Confirm the metadata block.** Build a workflow with an HTTP node targeting
+   `http://169.254.169.254/latest/meta-data/iam/security-credentials/`. Run it; confirm it's rejected.
+   Now point it at `https://api.github.com/repos/facebook/react` — confirm it succeeds. *Why does the
+   scanner's own `/api/scan/github` call still work?* (See §5.2.)
+2. **Off-by-one hunt.** In `ssrf.test.ts`, add cases for `172.16.0.0`, `172.31.255.255` (blocked) and
+   `172.15.255.255`, `172.32.0.1` (allowed). Break the range check on purpose and watch the tests fail.
+3. **Fail-closed cycles.** Submit `a→b→c→a`; observe the error includes the cycle path. Then a self-loop
+   `a→a`. Then a valid DAG — confirm it runs.
+4. **Rate-limit headers.** Hit the endpoint 11× quickly; observe the `429` + `Retry-After` /
+   `X-RateLimit-Remaining`. Change `limit`/`windowMs` and re-observe.
+5. **Red-team (stretch).** Write `evil.example` DNS that resolves to `127.0.0.1`, point the HTTP node at
+   it, and show the literal check **doesn't** stop it (A9). Then sketch a fix (resolve + check resolved
+   IP + pin). Discuss the latency/complexity trade-off.
+
+**Discussion:** Where else in this app does untrusted input choose a side effect? (Hint: the
+`javascript`/`tool` node's `new Function` — a future tutorial.) Should rate limits be per-IP, per-token,
+or both — and what breaks each?
+
+## 8. Takeaways, mappings & further reading
+
+- **Untrusted input that selects a server side effect is the root pattern** behind SSRF *and* excessive
+  agency. Validate the *destination/action*, not just the *content*.
+- **Provenance can be a security property:** the SSRF exemption shows the same value (localhost) is safe
+  or unsafe depending on who supplied it.
+- **Fail closed, ship the 80%, document the residual** (DNS rebinding, IP rotation) instead of pretending.
+
+| Control | CWE | OWASP |
+|---|---|---|
+| SSRF guard | CWE-918 (SSRF) | A10:2021 SSRF · LLM06 Excessive Agency |
+| Cycle detection | CWE-835 (infinite loop) | Unbounded Consumption |
+| Rate limiting | CWE-770 (alloc w/o limits) | API4:2023 Unrestricted Resource Consumption |
+
+**Further reading:** PortSwigger Web Security Academy — SSRF; OWASP SSRF Prevention Cheat Sheet; OWASP
+Top 10 for LLM Applications (LLM06); NIST AI 600-1; the companion `urw-llm-pipeline-design.md`.

--- a/docs/AI-Security/osv-scanner/02-secrets-at-rest-byok-key-encryption-2026-06-14-draft.md
+++ b/docs/AI-Security/osv-scanner/02-secrets-at-rest-byok-key-encryption-2026-06-14-draft.md
@@ -1,0 +1,194 @@
+# Tutorial 02 — Secrets at Rest: BYOK Key Encryption in a Zero-Backend App
+
+| | |
+|---|---|
+| **Series** | AI Security Tutorials — TopFlow |
+| **Level** | Intermediate |
+| **Source** | W1 key-encryption hardening (`lib/security/encryption.ts` + client wiring) |
+| **Files** | `lib/security/encryption.ts`, `components/api-settings-dialog.tsx`, `components/workflow-input-dialog.tsx`, `components/execution-panel.tsx` |
+| **Status** | Draft — 2026-06-14 |
+| **Est. time** | 45–75 min (with labs) |
+
+### Learning objectives
+(1) Reason about **encryption at rest** vs in-transit vs in-use; (2) threat-model **BYOK secrets** in a
+no-backend, localStorage-first app; (3) understand the **key-custody spectrum** and why a client-held
+key has hard limits; (4) read a real bug-and-fix (AES-GCM with an *ephemeral* key) and a
+backward-compatible migration; (5) state honestly what this control does and does **not** stop.
+
+---
+
+## 1. Context & architecture
+
+TopFlow is **BYOK (bring your own key)** and deliberately has **no backend datastore** — its privacy
+pitch is "your keys never leave your browser / are never stored on our servers." Two kinds of secret
+live in the browser's `localStorage`:
+- **AI provider keys** (`ai-agent-api-keys`: OpenAI/Anthropic/Google/Groq) — entered in the API
+  Settings dialog.
+- **GitHub token** (`ai-agent-github-token`) — entered in the scanner's input dialog (Tutorial 01's
+  BYOK scan-data axis).
+
+Both were stored **in plaintext**. On execution they're read from `localStorage` and POSTed in the
+`/api/execute-workflow` body.
+
+```mermaid
+flowchart LR
+  UI[Settings / scanner dialog] -->|plaintext today| LS[(localStorage)]
+  LS -->|read| EXE[execute-workflow client]
+  EXE -->|request body| SRV[(serverless function)]
+  X1[shared device / extension / XSS] -. reads .-> LS
+  classDef bad fill:#fee,stroke:#c00,color:#900;
+  class X1 bad
+```
+
+This tutorial adds **encryption at rest** for both secrets — and, just as importantly, is precise
+about the threat it does and doesn't address.
+
+## 2. Security mechanism (the concept)
+
+**Encryption at rest** protects data while it sits in storage. We use **AES-256-GCM** (authenticated
+symmetric encryption) via the browser-native **Web Crypto API** (`crypto.subtle`). GCM gives
+confidentiality **and** integrity (a tampered ciphertext fails to decrypt). Each value uses a random
+**96-bit IV**, and the stored format is `encrypted:<base64(iv || ciphertext)>`.
+
+The hard part of any encryption scheme is **key management** — *where does the key live, and who can
+reach it?* That question, not the cipher, decides how much protection you actually get (see §5).
+
+## 3. Threat model (for this architecture)
+
+**Asset:** the user's BYOK secrets (AI keys, GitHub token) — long-lived, high-value credentials.
+
+**Trust boundaries:** (a) other code/users with access to the same browser profile (extensions, shared
+devices, another tab/script via XSS); (b) the network (TLS handles this); (c) the serverless function
+(keys transit it on live runs — a *separate* concern, see §5.6).
+
+**STRIDE (storage-focused):**
+
+| STRIDE | Threat |
+|---|---|
+| **I**nfo disclosure | Plaintext keys readable from `localStorage` by a shared-device user, a malicious browser extension, or injected script. **(primary)** |
+| **T**ampering | Swapped/poisoned stored key → GCM detects on decrypt (auth tag). |
+| **R**epudiation / **S**poofing / **E**oP / **D**oS | Out of scope for at-rest storage here. |
+
+Mappings: **CWE-312 Cleartext Storage of Sensitive Information**, **CWE-522 Insufficiently Protected
+Credentials**, **CWE-320 Key Management Errors**.
+
+## 4. Attack trees
+
+```
+GOAL: steal the user's BYOK secrets from the browser
+├── T1 read plaintext localStorage directly
+│     ├── T1a shared/kiosk device, victim left logged in     [raised: now ciphertext at rest]
+│     ├── T1b malicious browser extension reading storage     [raised: ciphertext, key separate-ish]
+│     └── T1c casual inspection / screen-share of devtools    [raised: ciphertext, not plaintext]
+├── T2 exfiltrate via injected script (XSS)
+│     └── T2a script reads BOTH ciphertext AND the key        [NOT stopped — key is in the page origin]
+├── T3 intercept in transit                                   [out of scope: TLS]
+└── T4 read on the server                                     [separate concern: keys transit serverless; not stored]
+```
+
+The decisive honesty: **encryption at rest raises the bar for T1 (at-rest exposure) but does NOT stop
+T2 (XSS)** — because the decryption key necessarily lives in the same origin the attacker's script
+runs in. Teaching this distinction is the whole point: *don't let "we encrypt it" become security
+theater.* The real XSS mitigations are elsewhere (CSP, input/output handling, the URW boundary).
+
+## 5. Design considerations (the key-custody spectrum)
+
+| Option | Protects against | Cost / downside |
+|---|---|---|
+| Static app key (in bundle) | Almost nothing (key is public) | Security theater — avoid |
+| **Persisted random key in localStorage** ← *what we ship* | Casual at-rest inspection, some extension/exfil cases | Not XSS-proof (key co-located) |
+| User-passphrase-derived key (PBKDF2/Argon2) | At-rest + many XSS-exfil cases (key not stored) | UX cost: prompt to unlock each session |
+| Server-side custody / secrets vault | The strongest | Breaks the zero-backend / privacy promise |
+
+Decisions made:
+1. **Persisted random key**, not static or server. It fits the privacy/zero-backend constraint while
+   removing plaintext-at-rest. We're explicit that it's not XSS-proof (a passphrase upgrade is the
+   documented next step).
+2. **Fix the cipher's fatal bug first (see §6).** The pre-existing module generated a *new random key
+   on every call*, so AES-GCM could never decrypt what it encrypted. Encryption that can't decrypt is
+   worse than none (it silently destroys the user's keys).
+3. **Backward-compatible migration.** Values are tagged with an `encrypted:` prefix; `decryptValue`
+   returns unprefixed (legacy plaintext) input unchanged, so existing users aren't locked out — values
+   re-encrypt on next save. No big-bang migration.
+4. **Fail safe on decrypt errors.** If a stored value can't be decrypted, fall back rather than crash
+   (the dialog clears the field for re-entry; `decryptApiKeys` keeps going per-key).
+5. **Async wiring across read sites.** Web Crypto is async, so the settings load/save, the scanner
+   token load/save, and the pre-send read in the execution panel all become `await`-based.
+6. **At-rest only — by scope.** Keys still transit the serverless function on live runs (they aren't
+   stored there). That's a *different* control (the README/claims-reconciliation item); this PR does
+   not change it, and the tutorial is explicit so the two aren't conflated.
+
+## 6. Implementation case study
+
+**The bug (before).** `getEncryptionKey()` did:
+```ts
+const keyData = new Uint8Array(32); crypto.getRandomValues(keyData)   // NEW key every call
+return crypto.subtle.importKey("raw", keyData, { name: "AES-GCM" }, …)
+```
+→ `encryptValue` and a later `decryptValue` use *different* keys → the GCM auth check always fails →
+nothing round-trips. (`decryptApiKeys` even swallowed the error and returned the ciphertext as the
+"key", which would silently break every AI call.)
+
+**The fix.** Generate once, **cache + persist** the raw key:
+```ts
+let cachedKey: CryptoKey | null = null
+async function getEncryptionKey() {
+  if (cachedKey) return cachedKey
+  let raw = loadPersistedKeyBytes()                 // localStorage (base64), if present
+  if (!raw) { raw = crypto.getRandomValues(new Uint8Array(32)); persistKeyBytes(raw) }
+  cachedKey = await crypto.subtle.importKey("raw", raw, { name: "AES-GCM", length: 256 }, false, ["encrypt","decrypt"])
+  return cachedKey
+}
+```
+
+**Encrypt / decrypt** stay the same shape (random IV, `encrypted:` prefix, GCM), now actually
+reversible. **Wiring:**
+- `api-settings-dialog.tsx` — `await encryptApiKeys(settings)` on save; `await decryptApiKeys(raw)` on
+  load (legacy plaintext passes through).
+- `workflow-input-dialog.tsx` — `await encryptValue(token)` on save; `decryptValue(...)` on load.
+- `execution-panel.tsx` — `await decryptApiKeys(...)` / `await decryptValue(token)` **before** building
+  the request body, so the server still receives usable plaintext secrets (at-rest only).
+
+**Testing the untestable-by-default.** `jsdom` (the default Jest env) lacks a full `crypto.subtle`, so
+the suite uses a per-file `/** @jest-environment node */` docblock and ensures the Web Crypto global on
+Node 18. Tests cover: round-trip, `encrypted:` tagging, **legacy plaintext passthrough**, random-IV
+(two ciphertexts differ yet both decrypt), and object encrypt/decrypt skipping empty values. (Validated
+locally: 9/9.)
+
+**Deferred (documented, not hidden):** passphrase-derived keys (real XSS-exfil resistance), and moving
+key custody server-side (would change the privacy model).
+
+## 7. Hands-on labs
+
+1. **See it work.** Save an OpenAI key in Settings. Open devtools → Application → Local Storage. Confirm
+   `ai-agent-api-keys` now holds `encrypted:…` (not `sk-…`), and a key blob lives under
+   `ai-agent-builder-encryption-key`. Reload; confirm the dialog still shows your key (decryption works).
+2. **Backward compatibility.** Manually set `ai-agent-api-keys` to a *plaintext* `{"openai":"sk-test"}`.
+   Reload Settings → the key still loads (legacy passthrough). Save → confirm it's now `encrypted:…`.
+3. **Prove the XSS limitation (the key lesson).** In the devtools console (acting as injected script),
+   run: read `localStorage["ai-agent-builder-encryption-key"]` and `localStorage["ai-agent-api-keys"]`.
+   Note you have *both key and ciphertext* — i.e., at-rest encryption did **not** stop this path.
+   Discuss: what *would*? (passphrase not stored; CSP to prevent the script; output-handling hygiene.)
+4. **Stretch — passphrase upgrade.** Replace the persisted random key with a PBKDF2-derived key from a
+   user passphrase (prompt on unlock). What threat does this now close (T2a)? What UX cost did you add?
+
+**Discussion:** Is "keys never stored on our servers" still accurate given live runs POST them to the
+serverless function? How would you word the claim precisely? (Foreshadows the claims-reconciliation
+hardening item.)
+
+## 8. Takeaways, mappings & further reading
+
+- **Key custody — not the cipher — determines real protection.** A client-held key can't defend against
+  same-origin script (XSS). Encryption at rest is a *layer*, not a substitute for CSP/output hygiene.
+- **Encryption that can't decrypt is a data-loss bug.** Always test the **round-trip**, and ship a
+  **backward-compatible migration** so you never lock users out.
+- **Be precise in claims.** "Encrypted at rest" ≠ "your keys are safe from any attacker."
+
+| Concern | CWE | Reference |
+|---|---|---|
+| Plaintext storage | CWE-312 | OWASP Cryptographic Storage Cheat Sheet |
+| Weak credential protection | CWE-522 | OWASP ASVS V2/V6 |
+| Key management | CWE-320 | MDN Web Crypto API; NIST SP 800-38D (GCM) |
+
+**Further reading:** OWASP Cryptographic Storage Cheat Sheet; MDN `SubtleCrypto`; OWASP Top 10 for LLM
+Apps (sensitive information disclosure); Tutorial 01 (egress hardening) and the URW design doc.

--- a/docs/AI-Security/osv-scanner/README.md
+++ b/docs/AI-Security/osv-scanner/README.md
@@ -1,0 +1,39 @@
+# AI Security Tutorials — TopFlow GitHub Security Scanner
+
+A hands-on cybersecurity / AI-security training series built from **real hardening work** on
+TopFlow's LLM workflow engine and its flagship GitHub Security Scanner. Each tutorial turns a
+shipped pull request into a teaching case study: you see the threat, the model, the attack, the
+design trade-offs, and the actual code that fixed it.
+
+> These are training materials. They reference real files and PRs in this repository so learners
+> can read the production code alongside the lesson.
+
+## Who this is for
+Application & platform engineers, security engineers, and AI/ML engineers shipping LLM-powered
+products. Comfort with TypeScript and basic web security is assumed; each tutorial recaps the
+concepts it depends on.
+
+## How each tutorial is structured
+A consistent template so the series compounds:
+
+1. **Context & architecture** — where the risk lives in this system.
+2. **Security mechanism** — the defensive concept(s), in general terms.
+3. **Threat model** — assets, trust boundaries, entry points, STRIDE mapping for *this* architecture.
+4. **Attack trees** — attacker goals decomposed into concrete paths (incl. the ones we did *not* fully close).
+5. **Design considerations** — the decisions and trade-offs, with the roads not taken.
+6. **Implementation case study** — a walkthrough of the real PR: code, tests, what was deferred and why.
+7. **Hands-on labs & exercises** — do/observe/break, plus discussion questions.
+8. **Takeaways, mappings & further reading** — OWASP / CWE / NIST / MITRE references and a checklist.
+
+## Tutorials
+| # | Topic | Source PR | Status |
+|---|---|---|---|
+| 01 | Securing workflow egress & execution: SSRF allowlisting, cycle detection, rate limiting | #12 | Draft 2026-06-14 |
+| 02 | Secrets at rest: BYOK key encryption in a zero-backend app | (W1 key-encryption) | Draft 2026-06-14 |
+
+_More to come as the W1 "5-layer defense" hardening lands (JS-sandbox isolation, etc.)._
+
+## Companion design docs
+- `docs/architecture/urw-llm-pipeline-design.md` — the Untrusted Reasoning Worker trust boundary.
+- `docs/architecture/osv-real-scan-design.md` — the real OSV scanning architecture.
+- `docs/development/osv-scanner/01-p0-security-hardening.md` — the hardening program these tutorials track.

--- a/lib/security/__tests__/encryption.test.ts
+++ b/lib/security/__tests__/encryption.test.ts
@@ -1,0 +1,44 @@
+/**
+ * @jest-environment node
+ */
+import { webcrypto } from "node:crypto"
+// Ensure the Web Crypto global exists in the Node test env (Node 18 doesn't expose it by default).
+if (!(globalThis as any).crypto) (globalThis as any).crypto = webcrypto
+
+import { encryptValue, decryptValue, encryptApiKeys, decryptApiKeys, isEncrypted } from "../encryption"
+
+describe("encryption (AES-GCM round-trip)", () => {
+  test("encryptValue → decryptValue returns the original (this is the bug the fix closes)", async () => {
+    const secret = "ghp_abc123_DEF-456"
+    const enc = await encryptValue(secret)
+    expect(enc).not.toBe(secret)
+    expect(enc.startsWith("encrypted:")).toBe(true)
+    expect(await decryptValue(enc)).toBe(secret)
+  })
+
+  test("isEncrypted reflects the prefix", async () => {
+    expect(isEncrypted("plain-value")).toBe(false)
+    expect(isEncrypted(await encryptValue("x"))).toBe(true)
+  })
+
+  test("decryptValue passes legacy plaintext through unchanged (backward compatible)", async () => {
+    expect(await decryptValue("sk-legacy-plaintext")).toBe("sk-legacy-plaintext")
+  })
+
+  test("random IV: two ciphertexts differ but both decrypt", async () => {
+    const a = await encryptValue("same")
+    const b = await encryptValue("same")
+    expect(a).not.toBe(b)
+    expect(await decryptValue(a)).toBe("same")
+    expect(await decryptValue(b)).toBe("same")
+  })
+
+  test("encryptApiKeys / decryptApiKeys round-trip; empty values are skipped", async () => {
+    const enc = await encryptApiKeys({ openai: "sk-o", anthropic: "sk-ant", google: "" })
+    expect(enc.openai.startsWith("encrypted:")).toBe(true)
+    expect(enc.google).toBeUndefined()
+    const dec = await decryptApiKeys(enc)
+    expect(dec.openai).toBe("sk-o")
+    expect(dec.anthropic).toBe("sk-ant")
+  })
+})

--- a/lib/security/__tests__/rate-limit.test.ts
+++ b/lib/security/__tests__/rate-limit.test.ts
@@ -1,0 +1,59 @@
+import { RateLimiter, MemoryRateLimitStore, rateLimitKey } from "../rate-limit"
+
+describe("RateLimiter (sliding window, injected clock)", () => {
+  test("allows up to the limit, blocks beyond, then resets after the window", async () => {
+    let now = 1000
+    const rl = new RateLimiter({ limit: 3, windowMs: 1000, now: () => now })
+
+    expect((await rl.check("k")).allowed).toBe(true) // 1
+    expect((await rl.check("k")).allowed).toBe(true) // 2
+    const third = await rl.check("k") // 3
+    expect(third.allowed).toBe(true)
+    expect(third.remaining).toBe(0)
+    expect((await rl.check("k")).allowed).toBe(false) // 4 → blocked
+
+    now += 1001 // entire window elapses
+    expect((await rl.check("k")).allowed).toBe(true) // allowed again
+  })
+
+  test("keys are isolated", async () => {
+    let now = 0
+    const rl = new RateLimiter({ limit: 1, windowMs: 1000, now: () => now })
+    expect((await rl.check("a")).allowed).toBe(true)
+    expect((await rl.check("a")).allowed).toBe(false)
+    expect((await rl.check("b")).allowed).toBe(true)
+  })
+
+  test("reports remaining and resetMs", async () => {
+    let now = 5000
+    const rl = new RateLimiter({ limit: 2, windowMs: 1000, now: () => now })
+    const first = await rl.check("k")
+    expect(first.remaining).toBe(1)
+    expect(first.limit).toBe(2)
+    now += 400
+    const second = await rl.check("k")
+    expect(second.remaining).toBe(0)
+    expect(second.resetMs).toBeLessThanOrEqual(1000)
+    expect(second.resetMs).toBeGreaterThan(0)
+  })
+})
+
+describe("rateLimitKey", () => {
+  test("distinguishes ip from ip+token and is stable", () => {
+    expect(rateLimitKey("1.2.3.4")).not.toBe(rateLimitKey("1.2.3.4", "tok"))
+    expect(rateLimitKey("1.2.3.4", "tok")).toBe(rateLimitKey("1.2.3.4", "tok"))
+    expect(rateLimitKey("")).toBe("anonymous")
+  })
+  test("does not leak the raw token", () => {
+    expect(rateLimitKey("1.2.3.4", "super-secret-token")).not.toContain("super-secret-token")
+  })
+})
+
+describe("MemoryRateLimitStore", () => {
+  test("prune removes stale keys", () => {
+    const store = new MemoryRateLimitStore()
+    store.hit("k", 100, 1000)
+    store.prune(2000, 1000) // 100 is older than 2000-1000=1000 → removed
+    expect(store.hit("k", 2000, 1000).length).toBe(1) // fresh count after prune
+  })
+})

--- a/lib/security/__tests__/ssrf.test.ts
+++ b/lib/security/__tests__/ssrf.test.ts
@@ -1,0 +1,68 @@
+import { isBlockedHost, checkOutboundUrl, assertSafeOutboundUrl, SsrfBlockedError } from "../ssrf"
+
+describe("isBlockedHost", () => {
+  test.each([
+    "localhost",
+    "127.0.0.1",
+    "127.1.2.3",
+    "0.0.0.0",
+    "10.0.0.5",
+    "192.168.1.10",
+    "172.16.0.1",
+    "172.31.255.255",
+    "169.254.169.254", // cloud metadata
+    "100.64.0.1", // CGNAT
+    "::1",
+    "fe80::1",
+    "fd00::1",
+    "::ffff:10.0.0.1", // IPv4-mapped private
+    "metadata.google.internal",
+    "db.internal",
+    "service.local",
+  ])("blocks %s", (host) => {
+    expect(isBlockedHost(host)).toBe(true)
+  })
+
+  test.each([
+    "api.github.com",
+    "api.osv.dev",
+    "example.com",
+    "8.8.8.8",
+    "93.184.216.34",
+    "172.32.0.1", // just outside the private /12
+    "172.15.0.1",
+    "raw.githubusercontent.com",
+  ])("allows %s", (host) => {
+    expect(isBlockedHost(host)).toBe(false)
+  })
+})
+
+describe("checkOutboundUrl", () => {
+  test("blocks cloud-metadata endpoint", () => {
+    expect(checkOutboundUrl("http://169.254.169.254/latest/meta-data/").safe).toBe(false)
+  })
+  test("blocks loopback with port", () => {
+    expect(checkOutboundUrl("http://127.0.0.1:3000/internal").safe).toBe(false)
+  })
+  test("blocks non-http scheme", () => {
+    expect(checkOutboundUrl("file:///etc/passwd").safe).toBe(false)
+  })
+  test("blocks invalid URL", () => {
+    expect(checkOutboundUrl("not a url").safe).toBe(false)
+  })
+  test("allows public https", () => {
+    expect(checkOutboundUrl("https://api.github.com/repos/x/y").safe).toBe(true)
+  })
+  test("allows public http", () => {
+    expect(checkOutboundUrl("http://example.com/").safe).toBe(true)
+  })
+})
+
+describe("assertSafeOutboundUrl", () => {
+  test("throws SsrfBlockedError for private targets", () => {
+    expect(() => assertSafeOutboundUrl("http://10.0.0.1/")).toThrow(SsrfBlockedError)
+  })
+  test("does not throw for public targets", () => {
+    expect(() => assertSafeOutboundUrl("https://api.osv.dev/v1/query")).not.toThrow()
+  })
+})

--- a/lib/security/__tests__/workflow-graph.test.ts
+++ b/lib/security/__tests__/workflow-graph.test.ts
@@ -1,0 +1,44 @@
+import { detectWorkflowCycle } from "../workflow-graph"
+
+const N = (...ids: string[]) => ids.map((id) => ({ id }))
+const E = (...pairs: Array<[string, string]>) => pairs.map(([source, target]) => ({ source, target }))
+
+describe("detectWorkflowCycle", () => {
+  test("acyclic DAG → no cycle", () => {
+    const r = detectWorkflowCycle(N("a", "b", "c", "d"), E(["a", "b"], ["b", "c"], ["b", "d"], ["c", "d"]))
+    expect(r.hasCycle).toBe(false)
+    expect(r.cycle).toBeUndefined()
+  })
+
+  test("simple cycle a→b→c→a", () => {
+    const r = detectWorkflowCycle(N("a", "b", "c"), E(["a", "b"], ["b", "c"], ["c", "a"]))
+    expect(r.hasCycle).toBe(true)
+    expect(r.cycle).toContain("a")
+    expect(r.cycle).toContain("b")
+    expect(r.cycle).toContain("c")
+  })
+
+  test("self-loop is a cycle", () => {
+    expect(detectWorkflowCycle(N("a"), E(["a", "a"])).hasCycle).toBe(true)
+  })
+
+  test("empty graph → no cycle", () => {
+    expect(detectWorkflowCycle([], []).hasCycle).toBe(false)
+  })
+
+  test("cycle in one disconnected component is detected", () => {
+    const r = detectWorkflowCycle(N("a", "b", "x", "y"), E(["a", "b"], ["x", "y"], ["y", "x"]))
+    expect(r.hasCycle).toBe(true)
+  })
+
+  test("a long DAG (scanner-shaped) is fine", () => {
+    const r = detectWorkflowCycle(
+      N("start", "p", "m", "s", "score", "grade", "rep", "ai", "ext", "img", "end"),
+      E(
+        ["start", "p"], ["p", "m"], ["p", "s"], ["m", "score"], ["s", "score"],
+        ["score", "grade"], ["grade", "rep"], ["rep", "ai"], ["ai", "ext"], ["ext", "img"], ["img", "end"],
+      ),
+    )
+    expect(r.hasCycle).toBe(false)
+  })
+})

--- a/lib/security/encryption.ts
+++ b/lib/security/encryption.ts
@@ -1,16 +1,50 @@
 const ENCRYPTION_KEY_NAME = "ai-agent-builder-encryption-key"
 const ENCRYPTED_DATA_PREFIX = "encrypted:"
 
-// Generate or retrieve encryption key
+// Generate-once, then REUSE a stable AES-GCM key.
+//
+// Why this matters: AES-GCM decryption only succeeds with the exact key used to
+// encrypt. The previous implementation generated a fresh random key on every call,
+// so nothing encrypted could ever be decrypted (the GCM auth tag never matched).
+// We now cache the key in memory and persist the raw bytes to localStorage so it
+// survives reloads.
+//
+// SECURITY NOTE: a client-held key only protects against plaintext-at-rest
+// inspection / casual exfiltration — it is NOT a defense against XSS (a script in
+// the page can read both the ciphertext and the key). True secret custody needs a
+// server or a user passphrase. See docs/AI-Security/osv-scanner/02-secrets-at-rest-*.
+let cachedKey: CryptoKey | null = null
+
+function loadPersistedKeyBytes(): Uint8Array | null {
+  try {
+    if (typeof localStorage === "undefined") return null
+    const b64 = localStorage.getItem(ENCRYPTION_KEY_NAME)
+    if (!b64) return null
+    return Uint8Array.from(atob(b64), (c) => c.charCodeAt(0))
+  } catch {
+    return null
+  }
+}
+
+function persistKeyBytes(bytes: Uint8Array): void {
+  try {
+    if (typeof localStorage === "undefined") return
+    localStorage.setItem(ENCRYPTION_KEY_NAME, btoa(String.fromCharCode(...bytes)))
+  } catch {
+    /* best-effort: in-memory cache still allows round-trips this session */
+  }
+}
+
 async function getEncryptionKey(): Promise<CryptoKey> {
-  // In a real app, you'd want to derive this from a user password or secure storage
-  // For this demo, we'll generate a key and store it in IndexedDB
-  // This is better than plaintext but not perfect - real apps should use server-side encryption
-
-  const keyData = new Uint8Array(32) // 256 bits
-  crypto.getRandomValues(keyData)
-
-  return await crypto.subtle.importKey("raw", keyData, { name: "AES-GCM", length: 256 }, false, ["encrypt", "decrypt"])
+  if (cachedKey) return cachedKey
+  let raw = loadPersistedKeyBytes()
+  if (!raw) {
+    raw = new Uint8Array(32) // 256-bit AES key
+    crypto.getRandomValues(raw)
+    persistKeyBytes(raw)
+  }
+  cachedKey = await crypto.subtle.importKey("raw", raw, { name: "AES-GCM", length: 256 }, false, ["encrypt", "decrypt"])
+  return cachedKey
 }
 
 // Encrypt a string value

--- a/lib/security/rate-limit.ts
+++ b/lib/security/rate-limit.ts
@@ -1,0 +1,94 @@
+/**
+ * Sliding-window rate limiter with a pluggable store.
+ *
+ * Default store is in-memory (per server instance). For multi-instance
+ * durability, implement `RateLimitStore` against Redis / Vercel KV and pass it
+ * to the limiter — that adapter is a documented follow-up (it requires a
+ * dependency + env config) in docs/development/osv-scanner/01-p0-security-hardening.md.
+ *
+ * The clock is injectable for deterministic testing.
+ */
+
+export interface RateLimitResult {
+  allowed: boolean
+  limit: number
+  remaining: number
+  /** Milliseconds until the window frees up for this key. */
+  resetMs: number
+}
+
+export interface RateLimitStore {
+  /**
+   * Record a hit at `now` for `key` and return the timestamps (ms) still within
+   * the trailing `windowMs` (including the just-recorded hit).
+   */
+  hit(key: string, now: number, windowMs: number): number[] | Promise<number[]>
+}
+
+/** In-memory sliding-window-log store (per process instance). */
+export class MemoryRateLimitStore implements RateLimitStore {
+  private hits = new Map<string, number[]>()
+
+  hit(key: string, now: number, windowMs: number): number[] {
+    const cutoff = now - windowMs
+    const recent = (this.hits.get(key) || []).filter((t) => t > cutoff)
+    recent.push(now)
+    this.hits.set(key, recent)
+    return recent
+  }
+
+  /** Drop keys with no hits inside the window (call periodically to bound memory). */
+  prune(now: number, windowMs: number): void {
+    const cutoff = now - windowMs
+    for (const [key, arr] of this.hits) {
+      const recent = arr.filter((t) => t > cutoff)
+      if (recent.length) this.hits.set(key, recent)
+      else this.hits.delete(key)
+    }
+  }
+}
+
+export interface RateLimiterOptions {
+  limit: number
+  windowMs: number
+  store?: RateLimitStore
+  now?: () => number
+}
+
+export class RateLimiter {
+  private readonly limit: number
+  private readonly windowMs: number
+  private readonly store: RateLimitStore
+  private readonly now: () => number
+
+  constructor(opts: RateLimiterOptions) {
+    this.limit = opts.limit
+    this.windowMs = opts.windowMs
+    this.store = opts.store || new MemoryRateLimitStore()
+    this.now = opts.now || (() => Date.now())
+  }
+
+  async check(key: string): Promise<RateLimitResult> {
+    const now = this.now()
+    const hits = await this.store.hit(key, now, this.windowMs)
+    const count = hits.length
+    const oldest = hits[0] ?? now
+    return {
+      allowed: count <= this.limit,
+      limit: this.limit,
+      remaining: Math.max(0, this.limit - count),
+      resetMs: Math.max(0, this.windowMs - (now - oldest)),
+    }
+  }
+}
+
+/** Stable rate-limit key from a client IP and an optional secret/token (hashed, never stored raw). */
+export function rateLimitKey(ip: string, token?: string): string {
+  return `${ip || "anonymous"}${token ? `:${hash(token)}` : ""}`
+}
+
+function hash(s: string): string {
+  let h = 5381
+  for (let i = 0; i < s.length; i++) h = ((h << 5) + h + s.charCodeAt(i)) >>> 0
+  return h.toString(36)
+}

--- a/lib/security/ssrf.ts
+++ b/lib/security/ssrf.ts
@@ -1,0 +1,97 @@
+/**
+ * SSRF egress guard for outbound HTTP made by workflow nodes.
+ *
+ * Blocks loopback / private / link-local / CGNAT / reserved / cloud-metadata
+ * targets and non-http(s) schemes. This is a hostname/literal-IP check — it does
+ * NOT resolve DNS, so DNS-rebinding (a public name that resolves to a private IP)
+ * is a documented residual risk (defense-in-depth follow-up); see
+ * docs/development/osv-scanner/01-p0-security-hardening.md.
+ *
+ * The execution engine only applies this to **user-supplied absolute URLs**;
+ * engine-generated relative app routes (e.g. the scanner's /api/scan/github) are
+ * trusted internal calls and are not checked.
+ */
+
+export class SsrfBlockedError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = "SsrfBlockedError"
+  }
+}
+
+const BLOCKED_HOSTNAMES = new Set<string>([
+  "localhost",
+  "ip6-localhost",
+  "ip6-loopback",
+  "metadata.google.internal",
+])
+
+function isIpv4(host: string): boolean {
+  return /^\d{1,3}(\.\d{1,3}){3}$/.test(host)
+}
+
+function isBlockedIpv4(ip: string): boolean {
+  const parts = ip.split(".").map((p) => Number(p))
+  if (parts.length !== 4 || parts.some((p) => Number.isNaN(p) || p < 0 || p > 255)) return false
+  const [a, b] = parts
+  if (a === 0) return true // 0.0.0.0/8 "this host"
+  if (a === 10) return true // 10.0.0.0/8 private
+  if (a === 127) return true // 127.0.0.0/8 loopback
+  if (a === 169 && b === 254) return true // 169.254.0.0/16 link-local (incl. cloud metadata)
+  if (a === 172 && b >= 16 && b <= 31) return true // 172.16.0.0/12 private
+  if (a === 192 && b === 168) return true // 192.168.0.0/16 private
+  if (a === 100 && b >= 64 && b <= 127) return true // 100.64.0.0/10 CGNAT
+  if (a >= 224) return true // 224.0.0.0/4 multicast + 240/4 reserved
+  return false
+}
+
+function isBlockedIpv6(host: string): boolean {
+  const h = host.toLowerCase().replace(/^\[/, "").replace(/\]$/, "")
+  if (h === "::1" || h === "::") return true // loopback / unspecified
+  if (h.startsWith("fe80")) return true // link-local
+  if (h.startsWith("fc") || h.startsWith("fd")) return true // unique-local fc00::/7
+  const mapped = h.match(/::ffff:(\d{1,3}(?:\.\d{1,3}){3})$/) // IPv4-mapped ::ffff:a.b.c.d
+  if (mapped) return isBlockedIpv4(mapped[1])
+  return false
+}
+
+/** True if the hostname/IP literal should be blocked for outbound requests. */
+export function isBlockedHost(hostname: string): boolean {
+  const host = (hostname || "").toLowerCase().trim().replace(/\.$/, "")
+  if (!host) return true
+  if (BLOCKED_HOSTNAMES.has(host)) return true
+  if (host.endsWith(".internal") || host.endsWith(".local")) return true
+  if (isIpv4(host)) return isBlockedIpv4(host)
+  if (host.includes(":")) return isBlockedIpv6(host)
+  return false
+}
+
+export interface SsrfCheck {
+  safe: boolean
+  reason?: string
+}
+
+/** Non-throwing variant: returns { safe, reason }. */
+export function checkOutboundUrl(rawUrl: string): SsrfCheck {
+  let u: URL
+  try {
+    u = new URL(rawUrl)
+  } catch {
+    return { safe: false, reason: `invalid URL "${rawUrl}"` }
+  }
+  if (u.protocol !== "http:" && u.protocol !== "https:") {
+    return { safe: false, reason: `blocked scheme "${u.protocol}" (only http/https allowed)` }
+  }
+  if (isBlockedHost(u.hostname)) {
+    return { safe: false, reason: `blocked host "${u.hostname}" (loopback/private/link-local/metadata)` }
+  }
+  return { safe: true }
+}
+
+/** Throws SsrfBlockedError when the URL targets a disallowed destination. */
+export function assertSafeOutboundUrl(rawUrl: string): void {
+  const result = checkOutboundUrl(rawUrl)
+  if (!result.safe) {
+    throw new SsrfBlockedError(`SSRF blocked: ${result.reason}`)
+  }
+}

--- a/lib/security/workflow-graph.ts
+++ b/lib/security/workflow-graph.ts
@@ -1,0 +1,74 @@
+/**
+ * Pre-execution workflow-graph safety checks.
+ *
+ * Cycle detection runs server-side BEFORE a workflow executes and fails closed:
+ * a cyclic graph could otherwise drive an infinite loop (browser hang, runaway
+ * API-credit burn). This is independent of any validation in the workflow engine
+ * package — defense in depth.
+ */
+
+export interface GraphNode {
+  id: string
+}
+export interface GraphEdge {
+  source: string
+  target: string
+}
+
+export interface CycleResult {
+  hasCycle: boolean
+  /** The node ids forming the detected cycle (first repeated id appears at both ends). */
+  cycle?: string[]
+}
+
+/**
+ * Detect a directed cycle via DFS coloring (white/gray/black). Returns the cycle
+ * path when found so callers can produce an actionable error message.
+ */
+export function detectWorkflowCycle(nodes: GraphNode[], edges: GraphEdge[]): CycleResult {
+  const adjacency = new Map<string, string[]>()
+  for (const node of nodes) adjacency.set(node.id, [])
+  for (const edge of edges) {
+    if (!adjacency.has(edge.source)) adjacency.set(edge.source, [])
+    adjacency.get(edge.source)!.push(edge.target)
+  }
+
+  const WHITE = 0
+  const GRAY = 1
+  const BLACK = 2
+  const color = new Map<string, number>()
+  for (const id of adjacency.keys()) color.set(id, WHITE)
+
+  const stack: string[] = []
+
+  const visit = (nodeId: string): string[] | null => {
+    color.set(nodeId, GRAY)
+    stack.push(nodeId)
+
+    for (const next of adjacency.get(nodeId) || []) {
+      const c = color.get(next) ?? WHITE
+      if (c === GRAY) {
+        // Back-edge → cycle. Slice the current path from the repeated node.
+        const start = stack.indexOf(next)
+        return stack.slice(start).concat(next)
+      }
+      if (c === WHITE) {
+        const found = visit(next)
+        if (found) return found
+      }
+    }
+
+    color.set(nodeId, BLACK)
+    stack.pop()
+    return null
+  }
+
+  for (const id of adjacency.keys()) {
+    if ((color.get(id) ?? WHITE) === WHITE) {
+      const found = visit(id)
+      if (found) return { hasCycle: true, cycle: found }
+    }
+  }
+
+  return { hasCycle: false }
+}

--- a/lib/topflow-execution-engine.ts
+++ b/lib/topflow-execution-engine.ts
@@ -15,6 +15,7 @@ import {
   renderReport,
   resolveReportModel
 } from './demo-mode'
+import { assertSafeOutboundUrl } from './security/ssrf'
 
 /**
  * TopFlow-specific execution engine
@@ -234,6 +235,11 @@ export class TopFlowExecutionEngine extends ExecutionEngine {
       // Server-side: use localhost
       const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000'
       finalUrl = `${baseUrl}${interpolatedUrl}`
+    } else {
+      // SSRF guard: applied to user-supplied absolute URLs only. Engine-generated
+      // relative app routes (handled above, e.g. the scanner's /api/scan/github)
+      // are trusted internal calls and are intentionally exempt.
+      assertSafeOutboundUrl(finalUrl)
     }
 
     const options: RequestInit = {


### PR DESCRIPTION
Both tasks delivered as draft PRs into dev.
Task 1 — AI-Security tutorial series → PR #13
[knowlingo/TopFlow#13](https://github.com/knowlingo/TopFlow/pull/13) creates docs/AI-Security/osv-scanner/:

    README.md — series index + the reusable template (I polished your thought process into: context/architecture → security mechanism → threat model (STRIDE) → attack trees → design considerations → implementation case study → hands-on labs → OWASP/CWE/NIST mappings).
    01-ssrf-cycle-detection-rate-limiting-2026-06-14-draft.md — the full case study of PR #12, with a data-flow diagram, attack trees (incl. the unclosed leaves like DNS rebinding), the allowlist-internal-routes design call, and labs (reach 169.254.169.254 and watch it blocked, force a cycle, trip the rate limiter).
    02-secrets-at-rest-byok-key-encryption-2026-06-14-draft.md — see Task 2.

Files are named with number + topic + draft date, as you asked.
Task 2 — continued W1: BYOK key encryption → PR #14 (+ Tutorial 02)
[knowlingo/TopFlow#14](https://github.com/knowlingo/TopFlow/pull/14) encrypts the AI keys + GitHub token at rest (AES-256-GCM, Web Crypto, no new dep). While wiring it I found and fixed a real bug: encryption.ts's getEncryptionKey() generated a fresh random key every call, so AES-GCM could never decrypt what it encrypted (silent key loss). Now it generates once, caches, and persists the key. Wired encrypt-on-save / decrypt-on-load into the settings + scanner dialogs and decrypt-before-send in the execution panel, with legacy-plaintext passthrough so no one is locked out. Round-trip tests pass locally 9/9. Tutorial 02 documents the mechanism, the bug-and-fix, and — importantly — the honest limitation: a client-held key is not XSS-proof.
Both are drafts → CI should run on each (Actions is live now).
A decision you'll want to make for the rest of W1
