### PR TITLE
Dev

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -251,7 +251,7 @@ export default function AboutPage() {
                 </a>
               </Button>
               <Button asChild variant="outline" size="lg">
-                <a href="https://linkedin.com/in/charliesu" target="_blank" rel="noopener noreferrer">
+                <a href="https://linkedin.com/in/charliesu-ai" target="_blank" rel="noopener noreferrer">
                   <Linkedin className="mr-2 h-5 w-5" />
                   Connect on LinkedIn
                 </a>

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -45,6 +45,24 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.9,
     },
     {
+      url: `${baseUrl}/about`,
+      lastModified,
+      changeFrequency: "monthly",
+      priority: 0.7,
+    },
+    {
+      url: `${baseUrl}/showcase`,
+      lastModified,
+      changeFrequency: "weekly",
+      priority: 0.8,
+    },
+    {
+      url: `${baseUrl}/privacy`,
+      lastModified,
+      changeFrequency: "yearly",
+      priority: 0.3,
+    },
+    {
       url: `${baseUrl}/docs`,
       lastModified,
       changeFrequency: "weekly",

--- a/components/schema-org.tsx
+++ b/components/schema-org.tsx
@@ -85,11 +85,6 @@ export function SchemaOrg() {
       "BYOK Model",
       "Demo Mode",
     ],
-    aggregateRating: {
-      "@type": "AggregateRating",
-      ratingValue: "5.0",
-      ratingCount: "1",
-    },
     author: {
       "@type": "Person",
       name: "Charlie Su",


### PR DESCRIPTION
seo: fix stale LinkedIn link, drop fabricated rating, add missing sitemap routes
Fixes the half-corrected LinkedIn URL on the about page, removes a
self-reported aggregateRating with no real review system behind it,
and adds /about, /showcase, /privacy to the sitemap.